### PR TITLE
Add HBLL INS to get_survey_sets()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Updates to gfdata
 
+## 2023-07-13
+- HBLL INS (ssid: 39, 40) are now included in the default call for `get_survey_sets()`
+
 ## 2019-05-2019
 - Year, month and catch calculation moved to sql code instead of tidy funcion 
 to reduce run time on already extracted data.

--- a/R/get-dat.R
+++ b/R/get-dat.R
@@ -115,7 +115,7 @@ NULL
 #' @param sleep System sleep in seconds between each survey-year
 #'   to be kind to the server.
 #' @rdname get_data
-get_survey_sets <- function(species, ssid = c(1, 3, 4, 16, 2, 14, 22, 36),
+get_survey_sets <- function(species, ssid = c(1, 3, 4, 16, 2, 14, 22, 36, 39, 40),
                             join_sample_ids = FALSE, verbose = FALSE,
                             sleep = 0.05) {
   # Just to pull out up to date list of ssids associated with trawl/ll gear type.


### PR DESCRIPTION
Include HBLL INS so that future calls to `get_survey_sets()` is more comprehensive.